### PR TITLE
feat: health check retorna 503 (Service Unavailable) quando healthcheck falha

### DIFF
--- a/src/payment-processor/Endpoints.cs
+++ b/src/payment-processor/Endpoints.cs
@@ -64,12 +64,18 @@ app.MapGet("/", async (HttpContext context) =>
 });
 
 app.MapGet("/payments/service-health", (
-ConfigurationHttpResponseFailure failure,
-    ConfigurationHttpResponseDelay delay)
-    => new ServicesAvailabilityWireResponse(
+    HttpContext context,
+    ConfigurationHttpResponseFailure failure,
+    ConfigurationHttpResponseDelay delay) =>
+{
+    if (failure.HttpResponseFailure == true) {
+        context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+    }
+
+    return new ServicesAvailabilityWireResponse(
         failure.HttpResponseFailure,
-        delay.HttpResponseDelay))
-        .RequireRateLimiting("service-health");
+        delay.HttpResponseDelay);
+}).RequireRateLimiting("service-health");
 
 app.MapPost("/payments", async (
     ILogger<Endpoint> logger,


### PR DESCRIPTION
# motivação

sendo 300% honesto, o framework que eu to usando não me permite consumir o body do health check, as opções que eu tenho na mão:
1. re-implementar o `HttpHealthCheck`, seja copiando o código fonte pra minha codebase ou fazendo a minha própria implementação usando os primitivos do framework
2. forkar o framework só pra isso (vai me quebrar na hora de fazer a entrega do projeto)
3. tentar mergear esse pr aqui

essa aqui é a parte do código fonte que dá pra ver a lib drenando e descartando o body da requisição: https://github.com/cloudflare/pingora/blob/main/pingora-load-balancing/src/health_check.rs#L252-L254

triste demais.

# alteração

agora toda vez que a flag global `failure` for `true` o endpoint de healthcheck continua respondendo normalmente, a única diferença é que o status vai ser `503` ao invés de `200`.

# resultado

## `failure == false`

### config

<img width="928" height="807" alt="image" src="https://github.com/user-attachments/assets/813625d9-2aa2-4910-b6c8-2208b43c7934" />

### request

<img width="1688" height="739" alt="image" src="https://github.com/user-attachments/assets/40f74eb7-7e14-4391-886b-fc9aef3220ac" />

## `failure == true`

### config

<img width="1501" height="735" alt="image" src="https://github.com/user-attachments/assets/ba477496-ea07-480e-963a-4260fc748579" />

### request

<img width="1547" height="723" alt="image" src="https://github.com/user-attachments/assets/833abe28-5954-49de-b2b1-9be103d514d1" />
